### PR TITLE
feat | Set mu auth scope in the header when defined in environment

### DIFF
--- a/.woodpecker/.feature.yml
+++ b/.woodpecker/.feature.yml
@@ -1,0 +1,13 @@
+steps:
+  build-and-push:
+    image: woodpeckerci/plugin-docker-buildx
+    settings:
+      repo: '${CI_REPO_OWNER%%io}/${CI_REPO_NAME}'
+      tags: 'feature-${CI_COMMIT_BRANCH##feature/}'
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+when:
+  - event: push
+    branch: [feature/*]

--- a/.woodpecker/.latest.yml
+++ b/.woodpecker/.latest.yml
@@ -1,10 +1,13 @@
-pipeline:
+steps:
   build:
-    image: plugins/docker
+    image: woodpeckerci/plugin-docker-buildx
     settings:
-      repo: ${CI_REPO}
+      repo: '${CI_REPO_OWNER}/${CI_REPO_NAME}'
       tags: latest
-    secrets: [ docker_username, docker_password ]
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
 when:
-  branch: master
-  event: push
+  - event: push
+    branch: master

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -1,10 +1,14 @@
-pipeline:
+steps:
   build:
-    image: plugins/docker
+    image: woodpeckerci/plugin-docker-buildx
     settings:
-      repo: ${CI_REPO}
-      tags: "${CI_COMMIT_TAG##v}"
-    secrets: [ docker_username, docker_password ]
+      platforms: linux/amd64,linux/arm64
+      repo: '${CI_REPO_OWNER}/${CI_REPO_NAME}'
+      tags: '${CI_COMMIT_TAG##v}'
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
 when:
-  event: tag
-  tag: v*
+  - event: tag
+    ref: refs/tags/v*

--- a/.woodpecker/.test-build.yml
+++ b/.woodpecker/.test-build.yml
@@ -1,16 +1,16 @@
-pipeline:
+steps:
   lint:
-    image: node:20-alpine
+    image: node:18-alpine
     commands:
       # Need git for pulling some package dependencies (erikap/sparql-client)
       - apk --no-cache add git
       - npm ci
       - npm run lint:js
   build:
-    image: plugins/docker
+    image: woodpeckerci/plugin-docker-buildx
     settings:
-      repo: ${CI_REPO}
+      platforms: linux/amd64,linux/arm64
+      repo: '${CI_REPO_OWNER}/${CI_REPO_NAME}'
       dry_run: true
 when:
-  event:
-    - pull_request
+  event: pull_request

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM semtech/mu-javascript-template:1.8.0
+FROM semtech/mu-javascript-template:1.9.1
 LABEL maintainer=info@redpencil

--- a/app.js
+++ b/app.js
@@ -28,7 +28,7 @@ app.use(async function (req, res, next) {
   }
 });
 
-//When checking and authorization suceeded, just proxy the request.
+//When checking and authorization succeeded, just proxy the request.
 //We need to intercept the request first to transform the body back to a normal string or the request keeps hanging because it might not look like all data has come through yet.
 app.use(
   '/sparql',
@@ -40,10 +40,8 @@ app.use(
       if (!body) return;
       const contentType = proxyReq.getHeader('Content-Type');
 
-      // eslint-disable-next-line no-undef
-      const authScopes = process.env.DEFAULT_MU_AUTH_SCOPE;
-      if (authScopes) {
-        proxyReq.setHeader('mu-auth-scope', authScopes);
+      if (env.DEFAULT_MU_AUTH_SCOPE) {
+        proxyReq.setHeader('mu-auth-scope', env.DEFAULT_MU_AUTH_SCOPE);
       }
       if (/application\/sparql-query/.test(contentType)) {
         proxyReq.setHeader('Content-Length', Buffer.byteLength(body));

--- a/app.js
+++ b/app.js
@@ -40,6 +40,7 @@ app.use(
       if (!body) return;
       const contentType = proxyReq.getHeader('Content-Type');
 
+      // eslint-disable-next-line no-undef
       const authScopes = process.env.DEFAULT_MU_AUTH_SCOPE;
       if (authScopes) {
         proxyReq.setHeader('mu-auth-scope', authScopes);

--- a/app.js
+++ b/app.js
@@ -39,6 +39,11 @@ app.use(
       const body = req.body;
       if (!body) return;
       const contentType = proxyReq.getHeader('Content-Type');
+
+      const authScopes = process.env.DEFAULT_MU_AUTH_SCOPE;
+      if (authScopes) {
+        proxyReq.setHeader('mu-auth-scope', authScopes);
+      }
       if (/application\/sparql-query/.test(contentType)) {
         proxyReq.setHeader('Content-Length', Buffer.byteLength(body));
         proxyReq.write(body.toString());

--- a/env.js
+++ b/env.js
@@ -18,6 +18,10 @@ export const LOGLEVEL = envvar
   .default('silent')
   .asEnum(['error', 'silent']);
 
+export const DEFAULT_MU_AUTH_SCOPE = envvar
+  .get('DEFAULT_MU_AUTH_SCOPE')
+  .asString();
+
 const PREFIXES = {
   rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
   xsd: 'http://www.w3.org/2001/XMLSchema#',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparql-authorization-wrapper-service",
-  "version": "0.0.1",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sparql-authorization-wrapper-service",
-      "version": "0.0.1",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@lblod/mu-auth-sudo": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparql-authorization-wrapper-service",
-  "version": "0.0.1",
+  "version": "1.1.1",
   "type": "module",
   "description": "Wrapper for executing SPARQL queries on a mu-semtech stack with some extra authorization checks.",
   "dependencies": {


### PR DESCRIPTION
For OPH-963 I want to limit the sparql endpoint so they can only read from a specific graph. I created this service for it https://github.com/lblod/sparql-endpoint-proxy-service/pull/1 but turns out this service looks very similar.  If we add the scope header to the request we can just use this service and remove the other service from lblod.